### PR TITLE
rollback

### DIFF
--- a/src/components/Icons.astro
+++ b/src/components/Icons.astro
@@ -1,43 +1,31 @@
 ---
 import {Icon} from 'astro-icon'
-// import { showToast } from './Icons.astro.0.mjs';
 const Email= import.meta.env.Email;
 const routes = [["https://www.linkedin.com/in/saranatour/","mdi:linkedin"],
                 ["https://github.com/saranatour1","mdi:github"],
                 [`mailto:${Email}`,"mdi:gmail"]];
 
-// console.log(Email)
 ---
 <script>
-  const links =document.querySelectorAll(".link");
-  const linkData = document.querySelectorAll("span")
+  const links = document.querySelectorAll(".link");
 
+  //The code is adding a click event listener to each element with the class "link" in the HTML document.
   links.forEach((link)=>{
-    link.addEventListener("click", ()=>copyToClipboard(link))
+    link.addEventListener("click" , ()=> goToPage(link.textContent))
   })
-  export let showToast = false;
 
-  const copyToClipboard =(link)=>{
-    let text = link.textContent;
+// The `goToPage` function is a JavaScript function that is called when a link is clicked. It takes the `href` parameter, which represents the URL of the link that was clicked.
+  const goToPage = (href)=>{
+    if(confirm(`are you sure you want to leave to ${href}?`)){
+      window.open(href, "_blank")?.focus();
+    }
+  } 
 
-    console.log(link.textContent)
-    navigator.clipboard.writeText(text)
-    .then(() => {
-      showToast = true;
-      console.log('Text copied to clipboard:', text);
-    })
-    .catch((error) => {
-      console.error('Error copying text to clipboard:', error);
-    });
-  }
-  console.log(linkData)
 </script>
-  
 
   <div class="flex justify-evenly w-16 items-end h-20">
-    <!-- {showToast && <p>Hello</p>} -->
     {routes.map(([key,value],idx)=> (
-         <button class={`link`}><span aria-hidden="true" hidden>{key}</span> <Icon name={value} /></button> 
+         <button class={`link`}> <span hidden>{key}</span><Icon name={value} /></button> 
     ))}
   </div>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,6 +37,7 @@ const googleTag= import.meta.env?.MEASUREMENT_ID;
       gtag('config',`${googleTag}`);
     </script>
 
+		<!-- for a later try :) -->
 		<ViewTransitions fallback="swap"/>
 	</head>
 	<body class="w-screen  bg-gray-100">


### PR DESCRIPTION
Rolled back from "Copy to clipboard", replaced it [window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) for now, I might change the entire thing soon
also [View Transitions](https://docs.astro.build/en/guides/view-transitions/#:~:text=View%20transitions%20update%20your%20page,navigate%20away%20to%20another%20page.) is still experimental, it has a problem with loading js in time of loading pages, so I should use something else to prevent "instant refresh", which is also coming from the meta default. 
Not going to lie, might go for Vue or next.
